### PR TITLE
Fixed the call to ctypes's find_library function.

### DIFF
--- a/csynclib.py
+++ b/csynclib.py
@@ -10,7 +10,7 @@ if os.path.exists('/usr/lib/libocsync.so.0'):
 elif os.path.exists('/usr/lib64/libocsync.so.0'):
 	_libraries['/usr/lib/libocsync.so.0'] = CDLL('/usr/lib64/libocsync.so.0')
 else:
-	path = ctypes.util.find_library('libocsync')
+	path = ctypes.util.find_library('ocsync')
 	if path:
 		print 'Found libocsync @', path
 		_libraries['/usr/lib/libocsync.so.0'] = CDLL(path)

--- a/version.dat
+++ b/version.dat
@@ -1,1 +1,1 @@
-{"head": "74f884492e94040fba59085244bda4f90103aad7", "float": 0.2, "string": "0.2"}
+{"head": "6ed982fffbdf9e5e019f901397f4916f3252eeee", "float": 0.2, "string": "0.2"}


### PR DESCRIPTION
The name parameter of the find_library function is the library name
without any prefix like lib, suffix like .so, .dylib or version number.
Since the name parameter was 'libocsync', it didn't find the library,
but with 'ocsync' as parameter it did find it.

I wouldn't be surprised if the hardcoded paths can now be removed, so
only relying on the find_library function.
