### PR TITLE
docs: Fix a few typos

### DIFF
--- a/create_csynclib.py
+++ b/create_csynclib.py
@@ -37,7 +37,7 @@ for tag in repo.tags:
     except ValueError:
         continue
 
-    #only new versions interessting us
+    #only new versions interesting us
     if version in known_versions:
         continue
 

--- a/csync/version.py
+++ b/csync/version.py
@@ -11,7 +11,7 @@ class ver(object):
 		self.loadVersion()
 		self.setup()
 	def setup(self):
-		"""sublass this to do something useful for yourself"""
+		"""subclass this to do something useful for yourself"""
 		pass
 	@property
 	def asFloat(self):


### PR DESCRIPTION
There are small typos in:
- create_csynclib.py
- csync/version.py

Fixes:
- Should read `interesting` rather than `interessting`.
- Should read `subclass` rather than `sublass`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md